### PR TITLE
Update server.js

### DIFF
--- a/javascript/receiver/node.js/server.js
+++ b/javascript/receiver/node.js/server.js
@@ -39,7 +39,7 @@ https.createServer(options, (req, res) => {
 		res.end('{"success":"true"}');		
 		//write to a file
 		  fs.open('C:\\temp\\webhookPayloads.txt', 'a', 666, function( e, id ) {
-			fs.write( id, message.text+'\n', null, 'utf8', function(){
+			fs.write( id, JSON.stringify(JSON.parse(body.trim()))+'\n', null, 'utf8', function(){
     fs.close(id, function(){
       console.log('file closed');
     });


### PR DESCRIPTION
Existing 'message.text' value returns 'message is not defined' reference error when payload is received, this alternative places the JSON payload on a single line in the specified text document.

![image](https://user-images.githubusercontent.com/77084423/109078533-7fd47200-76cb-11eb-9f07-4187aa8fc1ab.png)
